### PR TITLE
Bug with AC status

### DIFF
--- a/mitsucon.ino
+++ b/mitsucon.ino
@@ -84,7 +84,7 @@ void mqttAutoDiscovery() {
   rootDiscovery["swing_mode_stat_t"]   = "~/tele/stat";
   rootDiscovery["swing_mode_stat_tpl"] = "{{ value_json.vane | lower }}";
   rootDiscovery["act_t"]               = "~/tele/stat";
-  rootDiscovery["act_tpl"]             = "{%if value_json.power=='OFF'%}off{%elif value_json.mode=='FAN'%}fan{%elif value_json.operating==false%}idle{%elif value_json.mode=='HEAT'%}heating{%elif value_json.mode=='COOL'%}cooling{%elif value_json.mode=='DRY'%}drying{%elif value_json.mode=='AUTO'%}idle{%else%}idle{%endif%}";
+  rootDiscovery["act_tpl"]             = "{%if value_json.power=='OFF'%}off{%elif value_json.mode=='FAN'%}fan{%elif value_json.operating and value_json.mode=='HEAT'%}heating{%elif value_json.operating and value_json.mode=='COOL'%}cooling{%elif value_json.operating and value_json.mode=='DRY'%}drying{%else%}idle{%endif%}";
 #ifdef _timersAttr
   rootDiscovery["json_attr_t"]         = "~/tele/attr";
 #endif

--- a/mitsucon.ino
+++ b/mitsucon.ino
@@ -83,8 +83,8 @@ void mqttAutoDiscovery() {
   rootDiscovery["swing_mode_cmd_t"]    = "~/cmnd/vane";
   rootDiscovery["swing_mode_stat_t"]   = "~/tele/stat";
   rootDiscovery["swing_mode_stat_tpl"] = "{{ value_json.vane | lower }}";
-  rootDiscovery["act_t"]               = "~/tele/curr";
-  rootDiscovery["act_tpl"]             = "{%set hp='climate.'+value_json.name|lower|replace(' ','_')%}{%if states(hp)=='off'%}off{%elif states(hp)=='fan'%}fan{%elif value_json.operating==false%}idle{%elif states(hp)=='heat'%}heating{%elif states(hp)=='cool' %}cooling{%elif states(hp)=='dry' %}drying{%elif states(hp)=='heat_cool'and(state_attr(hp,'temperature')-state_attr(hp,'current_temperature')>0)%}heating{%elif states(hp)=='heat_cool'and(state_attr(hp,'temperature')-state_attr(hp,'current_temperature')<0)%}cooling{%endif%}";
+  rootDiscovery["act_t"]               = "~/tele/stat";
+  rootDiscovery["act_tpl"]             = "{%if value_json.power=='OFF'%}off{%elif value_json.mode=='HEAT'%}heating{%elif value_json.mode=='COOL'%}cooling{%elif value_json.mode=='DRY'%}drying{%elif value_json.mode=='FAN'%}fan{%elif value_json.mode=='AUTO'%}idle{%else%}idle{%endif%}";
 #ifdef _timersAttr
   rootDiscovery["json_attr_t"]         = "~/tele/attr";
 #endif

--- a/mitsucon.ino
+++ b/mitsucon.ino
@@ -84,7 +84,7 @@ void mqttAutoDiscovery() {
   rootDiscovery["swing_mode_stat_t"]   = "~/tele/stat";
   rootDiscovery["swing_mode_stat_tpl"] = "{{ value_json.vane | lower }}";
   rootDiscovery["act_t"]               = "~/tele/stat";
-  rootDiscovery["act_tpl"]             = "{%if value_json.power=='OFF'%}off{%elif value_json.mode=='HEAT'%}heating{%elif value_json.mode=='COOL'%}cooling{%elif value_json.mode=='DRY'%}drying{%elif value_json.mode=='FAN'%}fan{%elif value_json.mode=='AUTO'%}idle{%else%}idle{%endif%}";
+  rootDiscovery["act_tpl"]             = "{%if value_json.power=='OFF'%}off{%elif value_json.mode=='FAN'%}fan{%elif value_json.operating==false%}idle{%elif value_json.mode=='HEAT'%}heating{%elif value_json.mode=='COOL'%}cooling{%elif value_json.mode=='DRY'%}drying{%elif value_json.mode=='AUTO'%}idle{%else%}idle{%endif%}";
 #ifdef _timersAttr
   rootDiscovery["json_attr_t"]         = "~/tele/attr";
 #endif
@@ -105,10 +105,11 @@ void mqttAutoDiscovery() {
 }
 
 void hpSettingsChanged() {
-  const size_t bufferSize = JSON_OBJECT_SIZE(6);
+  const size_t bufferSize = JSON_OBJECT_SIZE(7);
   DynamicJsonDocument root(bufferSize);
 
   heatpumpSettings currentSettings = hp.getSettings();
+  heatpumpStatus currentStatus = hp.getStatus();
 
   root["power"]       = currentSettings.power;
   root["mode"]        = currentSettings.mode;
@@ -116,6 +117,7 @@ void hpSettingsChanged() {
   root["fan"]         = currentSettings.fan;
   root["vane"]        = currentSettings.vane;
   root["wideVane"]    = currentSettings.wideVane;
+  root["operating"]   = currentStatus.operating;
 
   char buffer[512];
   serializeJson(root, buffer);


### PR DESCRIPTION
Problem: The Mitsubishi heat pump integration was always showing as "idle" in Home Assistant, regardless of the actual operating status of the heat pump.

Root Cause: The Home Assistant auto-discovery configuration contained a flawed action template that:
Used the wrong MQTT topic (~/tele/curr instead of ~/tele/stat)
Attempted circular logic by referencing the climate entity state within the template itself.
Had logic that didn't properly map heat pump modes to Home Assistant status values.


1. Simplified the action template to directly map heat pump status to Home Assistant climate actions.
2. Changed the action topic from ~/tele/curr to ~/tele/stat to access the correct data fields.
3. Removed circular dependencies by eliminating references to the climate entity state within the template.

 
heatpump0/tele/stat
```JSON
{
  "power": "ON",
  "mode": "COOL",
  "temperature": 24,
  "fan": "AUTO",
  "vane": "1",
  "wideVane": "<<"
}
```


heatpump0/tele/curr
```JSON
{
  "name": "Heat Pump 0",
  "roomTemperature": 24.5,
  "operating": true
}
```